### PR TITLE
[refactor] domain 환경변수로 변경

### DIFF
--- a/.github/workflows/cicd-workflow.yml
+++ b/.github/workflows/cicd-workflow.yml
@@ -88,8 +88,9 @@ jobs:
           export JWT_SECRET=${{ secrets.JWT_SECRET }}
           export JWT_EXPIRATION=${{ secrets.JWT_EXPIRATION }}
           export DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
+          export ADMIN_DOMAIN=${{ secrets.ADMIN_DOMAIN }}
           export TZ=Asia/Seoul
           
           docker compose pull
           docker compose up -d
-
+          

--- a/.github/workflows/cicd-workflow.yml
+++ b/.github/workflows/cicd-workflow.yml
@@ -89,6 +89,7 @@ jobs:
           export JWT_EXPIRATION=${{ secrets.JWT_EXPIRATION }}
           export DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
           export ADMIN_DOMAIN=${{ secrets.ADMIN_DOMAIN }}
+          export CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}
           export TZ=Asia/Seoul
           
           docker compose pull

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION: ${JWT_EXPIRATION}
       ADMIN_DOMAIN: ${ADMIN_DOMAIN}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
       TZ: Asia/Seoul
     healthcheck:
       test: curl --fail --silent --show-error http://spring:8080/actuator/health || exit 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,7 @@ services:
       DISCORD_WEBHOOK_URL: ${DISCORD_WEBHOOK_URL}
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION: ${JWT_EXPIRATION}
+      ADMIN_DOMAIN: ${ADMIN_DOMAIN}
       TZ: Asia/Seoul
     healthcheck:
       test: curl --fail --silent --show-error http://spring:8080/actuator/health || exit 1

--- a/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/attendance/AttendanceController.java
@@ -1,8 +1,6 @@
 package gdsc.konkuk.platformcore.controller.attendance;
 
 import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.apiPath;
-import static gdsc.konkuk.platformcore.global.consts.SPAConstants.SPA_ADMIN_ATTENDANCE_FAIL_REDIRECT_URL;
-import static gdsc.konkuk.platformcore.global.consts.SPAConstants.SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL;
 import static org.springframework.http.HttpStatusCode.valueOf;
 
 import gdsc.konkuk.platformcore.application.attendance.AttendanceService;
@@ -13,6 +11,7 @@ import gdsc.konkuk.platformcore.controller.attendance.dtos.AttendanceInfo;
 import gdsc.konkuk.platformcore.controller.attendance.dtos.AttendanceRegisterRequest;
 import gdsc.konkuk.platformcore.controller.attendance.dtos.AttendanceResponse;
 import gdsc.konkuk.platformcore.domain.attendance.entity.Attendance;
+import gdsc.konkuk.platformcore.global.consts.SPAConstants;
 import gdsc.konkuk.platformcore.global.responses.SuccessResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URI;
@@ -42,6 +41,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 public class AttendanceController {
 
     private final AttendanceService attendanceService;
+    private final SPAConstants spaConstants;
 
     @GetMapping
     public ResponseEntity<SuccessResponse> getEventsOfTheMonthWithAttendance(
@@ -61,7 +61,7 @@ public class AttendanceController {
 
             HttpHeaders headers = new HttpHeaders();
             headers.setCacheControl(CacheControl.noStore());
-            headers.add("Location", SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL);
+            headers.add("Location", spaConstants.getSpaAttendanceSuccessRedirectUrl());
 
             return new ResponseEntity<>(headers,
                     valueOf(HttpServletResponse.SC_TEMPORARY_REDIRECT));
@@ -70,7 +70,7 @@ public class AttendanceController {
 
             HttpHeaders headers = new HttpHeaders();
             headers.setCacheControl(CacheControl.noStore());
-            headers.add("Location", SPA_ADMIN_ATTENDANCE_FAIL_REDIRECT_URL);
+            headers.add("Location", spaConstants.getSpaAttendanceFailRedirectUrl());
             
             return new ResponseEntity<>(headers,
                     valueOf(HttpServletResponse.SC_TEMPORARY_REDIRECT));

--- a/src/main/java/gdsc/konkuk/platformcore/filter/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/filter/auth/CustomAuthenticationSuccessHandler.java
@@ -1,11 +1,10 @@
 package gdsc.konkuk.platformcore.filter.auth;
 
-import static gdsc.konkuk.platformcore.global.consts.SPAConstants.SPA_ADMIN_LOGIN_REDIRECT_URL;
-
 import gdsc.konkuk.platformcore.application.member.exceptions.MemberErrorCode;
 import gdsc.konkuk.platformcore.application.member.exceptions.UserNotFoundException;
 import gdsc.konkuk.platformcore.domain.member.entity.Member;
 import gdsc.konkuk.platformcore.domain.member.repository.MemberRepository;
+import gdsc.konkuk.platformcore.global.consts.SPAConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -23,6 +22,7 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final SPAConstants spaConstants;
 
     @Override
     public void onAuthenticationSuccess(
@@ -39,6 +39,6 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
         // TODO: Admin이 아닌 여러 클라이언트를 사용하게 될 경우, authorization code를 통한 POST 로그인으로 변경 필요
-        response.sendRedirect(SPA_ADMIN_LOGIN_REDIRECT_URL + "#" + token);
+        response.sendRedirect( spaConstants.getSpaAttendanceSuccessRedirectUrl()+ "#" + token);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/filter/auth/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/filter/auth/CustomAuthenticationSuccessHandler.java
@@ -39,6 +39,6 @@ public class CustomAuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
         // TODO: Admin이 아닌 여러 클라이언트를 사용하게 될 경우, authorization code를 통한 POST 로그인으로 변경 필요
-        response.sendRedirect( spaConstants.getSpaAttendanceSuccessRedirectUrl()+ "#" + token);
+        response.sendRedirect( spaConstants.getSpaAdminLoginRedirectUrl()+ "#" + token);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/global/configs/CorsConfig.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/configs/CorsConfig.java
@@ -3,9 +3,9 @@ package gdsc.konkuk.platformcore.global.configs;
 
 import java.util.Arrays;
 
-import gdsc.konkuk.platformcore.global.consts.PlatformConstants;
+import gdsc.konkuk.platformcore.global.props.CorsProps;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -13,15 +13,16 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(CorsProps.class)
 public class CorsConfig {
 
-    private final PlatformConstants platformConstants;
+    private final CorsProps corsProps;
 
     @Bean
     public UrlBasedCorsConfigurationSource getConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(platformConstants.getAllowedOriginsList());
+        configuration.setAllowedOriginPatterns(corsProps.allowedOrigins());
         configuration.setAllowedMethods(
                 Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/gdsc/konkuk/platformcore/global/configs/CorsConfig.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/configs/CorsConfig.java
@@ -1,21 +1,27 @@
 package gdsc.konkuk.platformcore.global.configs;
 
-import static gdsc.konkuk.platformcore.global.consts.PlatformConstants.allowedOrigins;
 
 import java.util.Arrays;
+
+import gdsc.konkuk.platformcore.global.consts.PlatformConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
+@RequiredArgsConstructor
 public class CorsConfig {
+
+    private final PlatformConstants platformConstants;
 
     @Bean
     public UrlBasedCorsConfigurationSource getConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOriginPatterns(allowedOrigins);
+        configuration.setAllowedOriginPatterns(platformConstants.getAllowedOriginsList());
         configuration.setAllowedMethods(
                 Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
@@ -1,15 +1,22 @@
 package gdsc.konkuk.platformcore.global.consts;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
 import java.util.List;
 
+@Configuration
+@ConfigurationProperties(prefix = "cors")
 public class PlatformConstants {
 
-    public static final List<String> allowedOrigins = List.of(
-            "http://localhost:5173", "https://stage.gdsc-konkuk.dev",
-            "https://gdsc-konkuk.dev", "https://admin.gdsc-konkuk.dev",
-            "https://member.gdsc-konkuk.dev", "https://landing.gdsc-konkuk.dev",
-            "https://gdgoc-konkuk.com", "https://admin.gdgoc-konkuk.com",
-            "https://stage.gdgoc-konkuk.com");
+    private String allowedOrigins;
+
+    public List<String> getAllowedOriginsList() {
+        return Arrays.stream(allowedOrigins.split(","))
+                     .map(String::trim)
+                     .toList();
+    }
 
     public static final Integer SOFT_DELETE_RETENTION_MONTHS = 3;
     public static final String EMAIL_RECEIVER_NAME_REGEXP = "\\{이름}";

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/PlatformConstants.java
@@ -1,22 +1,6 @@
 package gdsc.konkuk.platformcore.global.consts;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-
-import java.util.Arrays;
-import java.util.List;
-
-@Configuration
-@ConfigurationProperties(prefix = "cors")
 public class PlatformConstants {
-
-    private String allowedOrigins;
-
-    public List<String> getAllowedOriginsList() {
-        return Arrays.stream(allowedOrigins.split(","))
-                     .map(String::trim)
-                     .toList();
-    }
 
     public static final Integer SOFT_DELETE_RETENTION_MONTHS = 3;
     public static final String EMAIL_RECEIVER_NAME_REGEXP = "\\{이름}";

--- a/src/main/java/gdsc/konkuk/platformcore/global/consts/SPAConstants.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/consts/SPAConstants.java
@@ -1,12 +1,21 @@
 package gdsc.konkuk.platformcore.global.consts;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@RequiredArgsConstructor
+@ConfigurationProperties("domain")
 public class SPAConstants {
 
-    public static final String SPA_ADMIN_BASE_URL = "https://admin.gdgoc-konkuk.com";
-    public static final String SPA_ADMIN_LOGIN_REDIRECT_URL =
-            SPA_ADMIN_BASE_URL + "/oauth/callback";
-    public static final String SPA_ADMIN_ATTENDANCE_SUCCESS_REDIRECT_URL =
-            SPA_ADMIN_BASE_URL + "/attendance-return/success";
-    public static final String SPA_ADMIN_ATTENDANCE_FAIL_REDIRECT_URL =
-            SPA_ADMIN_BASE_URL + "/attendance-return/fail";
+    private final String admin;
+
+    public String getSpaAdminLoginRedirectUrl() {
+        return admin + "/oauth/callback";
+    }
+    public String getSpaAttendanceSuccessRedirectUrl() {
+        return admin + "/attendance-return/success";
+    }
+    public String getSpaAttendanceFailRedirectUrl() {
+        return admin + "/attendance-return/fail";
+    }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/global/props/CorsProps.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/props/CorsProps.java
@@ -1,0 +1,10 @@
+package gdsc.konkuk.platformcore.global.props;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "cors")
+public record CorsProps(
+        List<String> allowedOrigins
+) {}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -51,3 +51,6 @@ discord:
 
 domain:
   admin: ${ADMIN_DOMAIN}
+
+cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -48,3 +48,6 @@ jwt:
 discord:
   webhook:
     url: ${DISCORD_WEBHOOK_URL}
+
+domain:
+  admin: ${ADMIN_DOMAIN}


### PR DESCRIPTION
## 변경한 부분

SPAContents 클래스 내부에 static final로 SPA_ADMIN관련 도메인 주소들을 `@ConfigurationProperties` 활용하여 수정하였습니다.

## 논의해볼 점
이미 `GoogleOidcConfig`클래스에 `@ConfigurationProperties`로 환경변수를 주입하는 방식을 사용하고 있어서, `SPAContents`에도 적용했습니다. 이로인해 **클래스 로딩 시점**에 초기화되던 static final 변수들이, **객체 생성 시점에 Spring이 주입하도록** 순서의 변화가 발생하였습니다. 
1. 테스트 코드 동작에는 문제가 없어 보이는데, 추가적으로 신경써야 할 부분이 있을까요?
2. (아직 미적용한 부분)`PlatformConstants`의 allowedOrigins 리스트도 static으로 활용되고 있어서, 이 부분에 변경한 SPAContents구조를 활용해 주입하는 구조로 바꾼다면 순서 변화가 발생하게 됩니다. 이부분도 괜찮을까요?
3. `PlatformConstants`의 allowedOrigins 리스트에 많은 도메인 주소들이 있는데 이부분도 환경변수 처리를 할까요?