### PR TITLE
[Feat] bulk로 member 등록하는 기능 추가

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberFinder.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberFinder.java
@@ -24,6 +24,9 @@ public class MemberFinder {
                 .findById(memberId)
                 .orElseThrow(() -> UserNotFoundException.of(MemberErrorCode.USER_NOT_FOUND));
     }
+    public List<String> filterExistingStudentIds(List<String> studentIds) {
+        return memberRepository.findExistingStudentIds(studentIds);
+    }
 
     public Map<Long, Member> fetchMembersByIdsAndBatch(List<Long> memberIds, String batch) {
         List<Member> members = memberRepository.findAllByIdsAndBatch(memberIds, batch);

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
@@ -49,6 +49,25 @@ public class MemberService {
         return memberRepository.save(MemberCreateCommand
                 .toEntity(memberCreateCommand));
     }
+    @Transactional
+    public List<Member> bulkRegister(List<MemberCreateCommand> memberCreateCommands) {
+        List<String> studentIds = memberCreateCommands.stream()
+            .map(MemberCreateCommand::getStudentId)
+            .toList();
+
+        List<String> existingStudentIds = memberRepository.findExistingStudentIds(studentIds);
+        if (!existingStudentIds.isEmpty()) {
+            throw UserAlreadyExistException.of(
+                MemberErrorCode.USER_ALREADY_EXISTS,
+                "이미 존재하는 유저 학번 List : " + existingStudentIds
+            );
+        }
+
+        List<Member> members = memberCreateCommands.stream()
+                .map(MemberCreateCommand::toEntity)
+                .toList();
+        return memberRepository.saveAll(members);
+    }
 
     @Transactional
     public void withdraw(Long currentId) {

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/MemberService.java
@@ -55,7 +55,7 @@ public class MemberService {
             .map(MemberCreateCommand::getStudentId)
             .toList();
 
-        List<String> existingStudentIds = memberRepository.findExistingStudentIds(studentIds);
+        List<String> existingStudentIds = memberFinder.filterExistingStudentIds(studentIds);
         if (!existingStudentIds.isEmpty()) {
             throw UserAlreadyExistException.of(
                 MemberErrorCode.USER_ALREADY_EXISTS,

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserAlreadyExistException.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserAlreadyExistException.java
@@ -13,7 +13,8 @@ public class UserAlreadyExistException extends BusinessException {
         return new UserAlreadyExistException(errorCode, errorCode.getLogMessage());
 
     }
+    // 유저 정보 중복시 어떤 정보가 중복되었는지 로그에 남기기 위한 메서드
     public static UserAlreadyExistException of(CustomErrorCode errorCode, String causeMember) {
-        return new UserAlreadyExistException(errorCode, errorCode.getLogMessage()+" "+causeMember);
+        return new UserAlreadyExistException(errorCode, errorCode.getLogMessage()+". "+causeMember);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserAlreadyExistException.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserAlreadyExistException.java
@@ -14,6 +14,6 @@ public class UserAlreadyExistException extends BusinessException {
 
     }
     public static UserAlreadyExistException of(CustomErrorCode errorCode, String causeMember) {
-        return new UserAlreadyExistException(errorCode, errorCode.getLogMessage()+causeMember);
+        return new UserAlreadyExistException(errorCode, errorCode.getLogMessage()+" "+causeMember);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserAlreadyExistException.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/member/exceptions/UserAlreadyExistException.java
@@ -11,5 +11,9 @@ public class UserAlreadyExistException extends BusinessException {
 
     public static UserAlreadyExistException of(CustomErrorCode errorCode) {
         return new UserAlreadyExistException(errorCode, errorCode.getLogMessage());
+
+    }
+    public static UserAlreadyExistException of(CustomErrorCode errorCode, String causeMember) {
+        return new UserAlreadyExistException(errorCode, errorCode.getLogMessage()+causeMember);
     }
 }

--- a/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
+++ b/src/main/java/gdsc/konkuk/platformcore/controller/member/MemberController.java
@@ -47,6 +47,17 @@ public class MemberController {
         return ResponseEntity.created(getCreatedURI(registeredMember.getId()))
                 .body(SuccessResponse.messageOnly());
     }
+    @PostMapping("/bulk")
+    public ResponseEntity<SuccessResponse> bulkSignup(
+            @RequestBody @Valid List<MemberRegisterRequest> registerRequests) {
+        List<Member> registeredMembers = memberService.bulkRegister(
+                registerRequests.stream()
+                        .map(MemberRegisterRequest::toCommand)
+                        .toList()
+        );
+        return ResponseEntity.created(getCreatedURI((long)registeredMembers.size()))
+                .body(SuccessResponse.messageOnly());
+    }
 
     @DeleteMapping("/{batch}/{memberId}")
     public ResponseEntity<SuccessResponse> withdraw(

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
@@ -20,5 +20,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByBatch(String batch);
 
+    @Query("SELECT m.studentId FROM Member m WHERE m.studentId IN :studentIds")
     List<String> findExistingStudentIds(List<String> studentIds);
 }

--- a/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/member/repository/MemberRepository.java
@@ -19,4 +19,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String memberEmail);
 
     List<Member> findAllByBatch(String batch);
+
+    List<String> findExistingStudentIds(List<String> studentIds);
 }

--- a/src/main/java/gdsc/konkuk/platformcore/global/controller/GlobalExceptionHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.global.controller;
 
+import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
 import gdsc.konkuk.platformcore.global.exceptions.BusinessException;
 import gdsc.konkuk.platformcore.global.exceptions.GlobalErrorCode;
 import gdsc.konkuk.platformcore.global.responses.ErrorResponse;
@@ -42,6 +43,14 @@ public class GlobalExceptionHandler {
         log.error("MethodArgumentTypeMismatchException Caught!", e);
         final ErrorResponse response = ErrorResponse.of(GlobalErrorCode.ARGUMENT_NOT_VALID);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UserAlreadyExistException.class)
+    protected ResponseEntity<ErrorResponse> handleUserAlreadyExistException(
+            UserAlreadyExistException e) {
+        log.error("UserAlreadyExistException Caught!", e);
+        final ErrorResponse response = ErrorResponse.of(e.getLogMessage(), e.getName());
+        return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)

--- a/src/main/java/gdsc/konkuk/platformcore/global/controller/GlobalExceptionHandler.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.global.controller;
 
+import gdsc.konkuk.platformcore.application.member.exceptions.MemberErrorCode;
 import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
 import gdsc.konkuk.platformcore.global.exceptions.BusinessException;
 import gdsc.konkuk.platformcore.global.exceptions.GlobalErrorCode;
@@ -49,7 +50,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleUserAlreadyExistException(
             UserAlreadyExistException e) {
         log.error("UserAlreadyExistException Caught!", e);
-        final ErrorResponse response = ErrorResponse.of(e.getLogMessage(), e.getName());
+        final ErrorResponse response = ErrorResponse.of(e.getLogMessage(), MemberErrorCode.USER_ALREADY_EXISTS);
         return new ResponseEntity<>(response, HttpStatus.CONFLICT);
     }
 

--- a/src/main/java/gdsc/konkuk/platformcore/global/responses/ErrorResponse.java
+++ b/src/main/java/gdsc/konkuk/platformcore/global/responses/ErrorResponse.java
@@ -25,4 +25,7 @@ public class ErrorResponse extends Response {
     public static ErrorResponse of(final String message, final String errorCode) {
         return new ErrorResponse(message, errorCode);
     }
+    public static ErrorResponse of(final String message, final CustomErrorCode errorCode) {
+        return new ErrorResponse(message, errorCode.getName());
+    }
 }

--- a/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
@@ -144,7 +144,7 @@ class MemberServiceTest {
             memberCreateCommand2.getStudentId(),
             memberCreateCommand3.getStudentId()
         );
-        given(memberRepository.findExistingStudentIds(studentIds))
+        given(memberFinder.filterExistingStudentIds(studentIds))
             .willReturn(List.of("12345678"));
 
         // when & then

--- a/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/member/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package gdsc.konkuk.platformcore.application.member;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,6 +25,9 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collections;
+import java.util.List;
 
 class MemberServiceTest {
 
@@ -87,6 +91,67 @@ class MemberServiceTest {
 
         // then
         assertThrows(UserAlreadyExistException.class, action);
+    }
+
+    @Test
+    @DisplayName("bulkRegister : bulk로 가입하려는 멤버들 회원가입 성공")
+    void should_success_when_newMembers_bulkRegister() {
+        // given
+        MemberCreateCommand memberCreateCommand1 = MemberRegisterRequestFixture.builder().build()
+                .getFixture()
+                .toCommand();
+        MemberCreateCommand memberCreateCommand2 = MemberRegisterRequestFixture.builder().build()
+                .getFixture()
+                .toCommand();
+
+        Member savedMember1 = MemberFixture.builder().build().getFixture();
+        Member savedMember2 = MemberFixture.builder().build().getFixture();
+
+        List<String> studentIds = List.of(
+            memberCreateCommand1.getStudentId(),
+            memberCreateCommand2.getStudentId()
+        );
+
+        given(memberRepository.findExistingStudentIds(studentIds))
+                .willReturn(Collections.emptyList()); // 기존 회원 없음
+        given(memberRepository.saveAll(any(List.class)))
+                .willReturn(List.of(savedMember1, savedMember2));
+
+        // when
+        var actual = subject.bulkRegister(
+                List.of(memberCreateCommand1, memberCreateCommand2));
+
+        // then
+        assertNotNull(actual);
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("bulkRegister : bulk로 가입하려는 멤버 중 기등록된 회원이 존재하는 경우 회원가입 실패")
+    void should_fail_when_already_exist_members_bulkRegister() {
+        // given
+        MemberCreateCommand memberCreateCommand1 = MemberRegisterRequestFixture.builder()
+                .studentId("12345678")
+                .build().getFixture().toCommand();
+        MemberCreateCommand memberCreateCommand2 = MemberRegisterRequestFixture.builder()
+                .studentId("87654321")
+                .build().getFixture().toCommand();
+        MemberCreateCommand memberCreateCommand3 = MemberRegisterRequestFixture.builder()
+                .studentId("12344321")
+                .build().getFixture().toCommand();
+        List<String> studentIds = List.of(
+            memberCreateCommand1.getStudentId(),
+            memberCreateCommand2.getStudentId(),
+            memberCreateCommand3.getStudentId()
+        );
+        given(memberRepository.findExistingStudentIds(studentIds))
+            .willReturn(List.of("12345678"));
+
+        // when & then
+        assertThrows(UserAlreadyExistException.class,
+            () -> subject.bulkRegister(List.of(
+                    memberCreateCommand1, memberCreateCommand2,memberCreateCommand3
+            )));
     }
 
     @Test

--- a/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/controller/member/MemberControllerTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gdsc.konkuk.platformcore.application.member.MemberService;
 import gdsc.konkuk.platformcore.application.member.dtos.AttendanceUpdateCommand;
 import gdsc.konkuk.platformcore.application.member.dtos.MemberCreateCommand;
+import gdsc.konkuk.platformcore.application.member.exceptions.MemberErrorCode;
 import gdsc.konkuk.platformcore.application.member.exceptions.UserAlreadyExistException;
 import gdsc.konkuk.platformcore.controller.member.dtos.AttendanceUpdateRequest;
 import gdsc.konkuk.platformcore.controller.member.dtos.MemberRegisterRequest;
@@ -221,7 +222,7 @@ class MemberControllerTest {
                                 .with(csrf()));
 
         // then
-        result.andDo(print()).andExpect(status().isBadRequest());
+        result.andDo(print()).andExpect(status().isConflict());
     }
 
 
@@ -309,7 +310,10 @@ class MemberControllerTest {
         given(memberService.bulkRegister(argThat(requests ->
             requests.stream().anyMatch(request -> "202400001".equals(request.getStudentId()))
         )))
-        .willThrow(UserAlreadyExistException.class);
+        .willThrow(UserAlreadyExistException.of(
+            MemberErrorCode.USER_ALREADY_EXISTS,
+            "이미 존재하는 유저 학번 List : [202400001]"  // 테스트용 메시지
+        ));
 
         // when
         ResultActions result =
@@ -323,7 +327,7 @@ class MemberControllerTest {
         // then
         result
                 .andDo(print())
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isConflict())
                 .andDo(
                         document(
                                 "member/bulk_register_fail",


### PR DESCRIPTION
## 📋요약
member들을 JSON 배열 형태로 일괄 등록할 수 있는 **bulk 회원등록 기능과 관련된 내용들을 추가**합니다.

## 🚀 변경점
- `POST` `/api/v1/members` 엔드포인트 추가
- 중복 학번 체크 및 에러 핸들링
- 트랜잭션 기반 bulk insert

## 기술적 내용

### bulk 요청 API Specification
엔드포인트 : `POST` `{baseurl}/api/v1/members`
아래 JSON 형식 데이터는 **더미 데이터**입니다.
```JSON
[
  {
    "studentId": "202111001",
    "name": "김민수",
    "email": "minsu.kim@university.ac.kr",
    "department": "컴퓨터공학과",
    "batch": "25-26",
    "role": "MEMBER"
  },
  {
    "studentId": "202111002", 
    "name": "박지영",
    "email": "jiyoung.park@university.ac.kr",
    "department": "경영학과",
    "batch": "25-26",
    "role": "MEMBER"
  },
  {
    "studentId": "202211003",
    "name": "이철호",
    "email": "cheolho.lee@university.ac.kr", 
    "department": "전자공학과",
    "batch": "25-26",
    "role": "CORE"
  }
]
```

### 등록 규칙
- member bulk 리스트로 추가 시, 해당 리스트에 포함된 유저 중 **기 등록된 member** 가 존재하지 않아야 합니다

### ✅ 등록 성공하는 경우
- HTTP 상태 코드: `201 CREATED`
- 응답 Location 헤더 : {baseurl}/{등록 멤버 수}형태의 URI 반환
- 응답 본문: Body에 아래 형식으로 반환
```JSON
{
  "message":"SUCCESS",
  "data":null,
  "success":true
}
```


### ⚠️ 등록 실패하는 경우
bulk 내용 중 **기 등록된 member** 가 존재 존재하는 경우, 다음 구조로 오류를 반환합니다

- HTTP 상태 코드: `409 CONFLICT`
- 응답 본문: Body에 아래 형식으로 반환
``` JSON
{
  "isSuccess":false,
  "message":"[ERROR] : 이미 존재하는 사용자. 이미 존재하는 유저 학번 List : [202400001,202400002]",
  "errorCode":"USER_ALREADY_EXISTS"
}
```

### 🧪테스팅

- bulk로 유저 추가할 때 기 등록된 멤버 존재하는 경우 오류(Controller/Service)
    -  오류 발생 본문 확인
- bulk 작동(Controller/Service)