### PR TITLE
fix : 메일 발송 성공 시 EMAIL_RECEIVER 테이블의 SENT_AT, SEND_STATUS 컬럼 업데이트

### DIFF
--- a/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
+++ b/src/main/java/gdsc/konkuk/platformcore/application/email/EmailService.java
@@ -74,6 +74,13 @@ public class EmailService {
     }
 
     @Transactional
+    public void completeEmailReceiver(Long receiverId) {
+        EmailReceiver receiver = emailReceiverRepository.findById(receiverId)
+            .orElseThrow(() -> EmailNotFoundException.of(EmailErrorCode.EMAIL_NOT_FOUND));
+        receiver.completeSend();
+    }
+
+    @Transactional
     public EmailTask update(Long emailId, EmailTaskUpsertCommand command) {
         EmailTask task = findById(emailId);
 

--- a/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceiver.java
+++ b/src/main/java/gdsc/konkuk/platformcore/domain/email/entity/EmailReceiver.java
@@ -66,6 +66,12 @@ public class EmailReceiver {
         }
     }
 
+    public void completeSend() {
+        this.sendStatus = EmailSendStatus.COMPLETED;
+        this.statusUpdatedAt = LocalDateTime.now();
+        this.sentAt = LocalDateTime.now();
+    }
+
     public boolean isPendingTimeout(int timeoutMinutes) {
         return this.sendStatus == EmailSendStatus.PENDING &&
             this.statusUpdatedAt != null &&

--- a/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/application/email/EmailServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.BDDMockito.when;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import gdsc.konkuk.platformcore.application.email.dtos.EmailTaskInfo;
@@ -85,6 +86,40 @@ class EmailServiceTest {
         assertEquals(emailTask2.getId(), actual.get(1).emailTask().getId());
     }
 
+    @Test
+    @DisplayName("이메일 수신자 완료 처리 - 수신자를 찾을 수 없는 경우 예외 발생")
+    void completeEmailReceiver_EmailNotFound_ThrowsException() {
+        // given
+        Long receiverId = 999L;
+        given(emailReceiverRepository.findById(receiverId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        EmailNotFoundException exception = assertThrows(
+            EmailNotFoundException.class,
+            () -> subject.completeEmailReceiver(receiverId)
+        );
+
+        verify(emailReceiverRepository).findById(receiverId);
+
+    }
+
+    @Test
+    @DisplayName("이메일 수신자 완료 처리 - null ID로 호출시 예외 발생")
+    void completeEmailReceiver_NullId_ThrowsException() {
+        // given
+        Long receiverId = null;
+        given(emailReceiverRepository.findById(receiverId))
+            .willReturn(Optional.empty());
+
+        // when & then
+        EmailNotFoundException exception = assertThrows(
+            EmailNotFoundException.class,
+            () -> subject.completeEmailReceiver(receiverId)
+        );
+
+        verify(emailReceiverRepository).findById(null);
+    }
 
     @Test
     @DisplayName("getTaskDetails : 특정 이메일 전송 작업 조회 성공")

--- a/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import gdsc.konkuk.platformcore.application.email.EmailService;
 import gdsc.konkuk.platformcore.application.email.dtos.EmailTaskInfo;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetail;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
@@ -31,13 +32,15 @@ class EmailClientTest {
 
     @Mock
     private JavaMailSender javaMailSender;
+    @Mock
+    private EmailService emailService;
 
     private EmailClient emailClient;
 
     @BeforeEach
     void setUp() {
         openMocks(this);
-        emailClient = spy(new EmailClient(javaMailSender));
+        emailClient = spy(new EmailClient(javaMailSender, emailService));
     }
 
     @Test

--- a/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
+++ b/src/test/java/gdsc/konkuk/platformcore/external/email/EmailClientTest.java
@@ -1,7 +1,7 @@
 package gdsc.konkuk.platformcore.external.email;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -15,6 +15,7 @@ import gdsc.konkuk.platformcore.application.email.EmailService;
 import gdsc.konkuk.platformcore.application.email.dtos.EmailTaskInfo;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailDetail;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailReceiver;
+import gdsc.konkuk.platformcore.domain.email.entity.EmailSendStatus;
 import gdsc.konkuk.platformcore.domain.email.entity.EmailTask;
 import gdsc.konkuk.platformcore.external.email.exceptions.EmailSendingException;
 import jakarta.mail.internet.MimeMessage;
@@ -112,5 +113,74 @@ class EmailClientTest {
 
         // then
         assertEquals("안녕하세요, guest1님 합격을 축하드립니다!. guest1님과 함께할 수 있어 기쁩니다.", result);
+    }
+
+    @Test
+    @DisplayName("completeSend() 호출 시 상태가 COMPLETED로 변경되고 시간이 설정된다")
+    void completeSend_ShouldUpdateStatusAndTimestamps() {
+        // given
+        EmailReceiver emailReceiver = EmailReceiver.builder()
+            .emailTaskId(1L)
+            .email("test@example.com")
+            .name("테스트 사용자")
+            .build();
+
+        LocalDateTime beforeCall = LocalDateTime.now().minusSeconds(1);
+
+        // when
+        emailReceiver.completeSend();
+
+        // then
+        LocalDateTime afterCall = LocalDateTime.now().plusSeconds(1);
+
+        assertAll(
+            () -> assertThat(emailReceiver.getSendStatus()).isEqualTo(EmailSendStatus.COMPLETED),
+            () -> assertThat(emailReceiver.getStatusUpdatedAt()).isNotNull(),
+            () -> assertThat(emailReceiver.getStatusUpdatedAt()).isAfter(beforeCall),
+            () -> assertThat(emailReceiver.getStatusUpdatedAt()).isBefore(afterCall),
+            () -> assertThat(emailReceiver.getSentAt()).isNotNull(),
+            () -> assertThat(emailReceiver.getSentAt()).isAfter(beforeCall),
+            () -> assertThat(emailReceiver.getSentAt()).isBefore(afterCall)
+        );
+    }
+
+    @Test
+    @DisplayName("WAITING 상태에서 completeSend() 호출 시 정상 동작")
+    void completeSend_FromWaitingStatus_ShouldWork() {
+        // given
+        EmailReceiver emailReceiver = EmailReceiver.builder()
+            .emailTaskId(1L)
+            .email("test@example.com")
+            .name("테스트 사용자")
+            .build();
+
+        // EmailReceiver는 생성시 WAITING 상태
+        assertThat(emailReceiver.getSendStatus()).isEqualTo(EmailSendStatus.WAITING);
+
+        // when
+        emailReceiver.completeSend();
+
+        // then
+        assertThat(emailReceiver.getSendStatus()).isEqualTo(EmailSendStatus.COMPLETED);
+    }
+
+        @Test
+    @DisplayName("completeSend() 호출 전후 sentAt 필드 변화 확인")
+    void completeSend_SentAtField_ShouldBeSetCorrectly() {
+        // given
+        EmailReceiver emailReceiver = EmailReceiver.builder()
+            .emailTaskId(1L)
+            .email("test@example.com")
+            .name("테스트 사용자")
+            .build();
+
+        // 초기 상태에서는 sentAt이 null이어야 함
+        assertThat(emailReceiver.getSentAt()).isNull();
+
+        // when
+        emailReceiver.completeSend();
+
+        // then
+        assertThat(emailReceiver.getSentAt()).isNotNull();
     }
 }


### PR DESCRIPTION
## 🔧수정내용
#82 와 관련된 수정 내용입니다.

현재DB를 보면 **이메일 발송 이후에도, SEND_STATUS 값이 `WAITING`으로 고정되어 있고, SENT_AT 부분이 업데이트되지 않은 모습**입니다.
이 문제를 해결하고자, Email Client/Receiver/Service부분을 수정하여 메일을 성공적으로 보냈을 때 해당 값들을 업데이트 하도록 하였습니다.

## 🤔생각해봐야 하는 점
현재는 메일 전송 완료시 EmailReceiver의 sendStatus를 바로 `COMPLETE`로 업데이트 하도록 했습니다. 
그러나, Enum값을 보면 `PENDING`을 거치는 형식으로 되어 있는것을 볼 수 있습니다.
 **이메일 전송 완료(`COMPLETE`)/전송 전(`WAITING`) 두 개로 나뉜다고 파악**해서 이 `PENDING`의 의미가 모호한 것 같습니다.
따라서 일단은 두 개의 상태로 분류하였습니다. 추후에 PENDING Enum이 어떤 의미인지 파악해야 할 것 같습니다.